### PR TITLE
Don't auto-require rvm/capistrano

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Example:
     before 'deploy:setup', 'rvm:install_rvm'
     before 'deploy:setup', 'rvm:install_ruby'
     
-    require "rvm-capistrano"
+    require "rvm/capistrano"
 
 
 ## Development

--- a/lib/rvm-capistrano.rb
+++ b/lib/rvm-capistrano.rb
@@ -1,1 +1,0 @@
-require 'rvm/capistrano'


### PR DESCRIPTION
Call `require 'rvm/capistrano'` from capistrano recipes instead of
`require 'rvm-capistrano'`.  This fixes an issue when the rvm-capistrano
gem is included via Bundler.setup.

Fixes #2.
