### PR TITLE
curl output shows as error in capistrano output 

### DIFF
--- a/lib/rvm/capistrano.rb
+++ b/lib/rvm/capistrano.rb
@@ -84,7 +84,7 @@ Capistrano::Configuration.instance(true).load do
       set :rvm_install_shell, :zsh
     EOF
     task :install_rvm do
-      command_fetch="curl -L get.rvm.io | "
+      command_fetch="curl -sL get.rvm.io | "
       case rvm_type
       when :root, :system
         if use_sudo == false && rvm_install_with_sudo == false


### PR DESCRIPTION
Because curl outputs download progress to stderr the output shows up as an error in the capistrano output. Can we run the curl with -s to suppress the error output?
