### PR TITLE
Fix require example in documentation

### DIFF
--- a/lib/rvm/capistrano.rb
+++ b/lib/rvm/capistrano.rb
@@ -159,6 +159,6 @@ end
 
 # E.g, to use ree and rails 3:
 #
-#   require 'rvm-capistrano'
+#   require 'rvm/capistrano'
 #   set :rvm_ruby_string, "ree@rails3"
 #


### PR DESCRIPTION
It looks like this used to be loaded via

```ruby
require 'rvm-capistrano'
```

but now this form is required.

```ruby
require 'rvm/capistrano'
```