### PR TITLE
Teach RVM about (un)installing a gem.

### DIFF
--- a/lib/rvm/capistrano.rb
+++ b/lib/rvm/capistrano.rb
@@ -153,6 +153,16 @@ module Capistrano
         end
       end
 
+      desc "Install a gem, 'cap rvm:install_gem GEM=my_gem'."
+      task :install_gem do
+        run "#{File.join(rvm_bin_path, "rvm")} #{rvm_ruby_string} do gem install #{ENV['GEM']}", :shell => "#{rvm_install_shell}"
+      end
+
+      desc "Uninstall a gem, 'cap rvm:uninstall_gem GEM=my_gem'."
+      task :uninstall_gem do
+        run "#{File.join(rvm_bin_path, "rvm")} #{rvm_ruby_string} do gem uninstall --no-executables #{ENV['GEM']}", :shell => "#{rvm_install_shell}"
+      end
+
     end
   end if const_defined? :Configuration
 end


### PR DESCRIPTION
I install RVM and ruby with `capistrano` (as opposed to a server setup tool such as Chef or Puppet).

Consequently, I'd like to be able to install a gem into the RVM gemset using `capistrano` as well.  Otherwise, I would need to log into the server to do so.  Using bundler via an application `Gemfile` is not a solution because some gems such as `passenger` (this is my case), should not be listed in the `Gemfile`.

This is a fairly naive implementation.  It does not expose any of the options to `gem install` or `gem uninstall`, and it assumes you want to remove executables when uninstalling.

In particular, the uninstall does not remove dependencies.  Rubygems does not do so either, but I do think it would be preferable.  (Aside, there is a [rubygems issue](https://github.com/rubygems/rubygems/issues/133) open for dependency removal.)

Thoughts?
