### PR TITLE
rvm-curl-config causes errors when running on shared home directory

### DIFF
--- a/lib/rvm/capistrano.rb
+++ b/lib/rvm/capistrano.rb
@@ -76,7 +76,7 @@ module Capistrano
     namespace :rvm do
 
       command_curl_start = <<-EOF.gsub(/^\s*/, '')
-        export CURL_HOME=${TMPDIR:-${HOME}}/.rvm-curl-config;
+        export CURL_HOME=${TMPDIR:-${HOME}}/.rvm-curl-config.$$;
         mkdir ${CURL_HOME}/;
         {
           [[ -r ${HOME}/.curlrc ]] && cat ${HOME}/.curlrc;


### PR DESCRIPTION
Our deploy user has an NFS-mounted home area.  Concurrent deploys try to create/delete ~/.rvm-curl-config and get in the way of each other:

**\* [err :: host1] mkdir:
**\* [err :: host1] cannot create directory `/home/deploy/.rvm-curl-config/'
*** [err :: host1] : File exists
*** [err :: host1]
*** [err :: host2] mkdir:
*** [err :: host2] cannot create directory`/home/deploy/.rvm-curl-config/'
**\* [err :: host2] : File exists
**\* [err :: host2]
