### PR TITLE
Add remaining autolib flags (3 and 4) to allow automatic installation of ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ end
  - `:disable` - fully disable autolibs, limit automated tasks
  - `:read`    - autolibs only in read only mode, do not change anything in system
  - `:fail`    - autolibs only in read only mode, fail if changes are required
- - `:enable`  - let RVM install what is needed for ruby, required `set :use_sudo, true`
+ - `:package` - let RVM install what is needed for ruby, required `set :use_sudo, true` or `set :rvm_install_with_sudo, true`
+ - `:enable`  - all behaviors from `:package`, plus installing a package manager in OSX
 
 - `:rvm_path` - force `$rvm_path`, only overwrite if standard paths can not be used
 - `:rvm_bin_path` - force `$rvm_bin_path`, only overwrite if standard paths can not be used

--- a/lib/rvm/capistrano.rb
+++ b/lib/rvm/capistrano.rb
@@ -216,9 +216,11 @@ ruby can not be installed when using :rvm_ruby_string => :#{ruby}
 
           autolibs_flag = fetch(:rvm_autolibs_flag, 2).to_s
           autolibs_flag_no_requirements = %w(
-            0 disable disabled
-            1 read    read-only
-            2 fail    read-fail
+            0 disable  disabled
+            1 read     read-only
+            2 fail     read-fail
+            3 packages install-packages
+            4 enable   enabled
           ).include?( autolibs_flag )
 
           if autolibs_flag_no_requirements


### PR DESCRIPTION
It looks like flags 3 and 4 were left out of the allowed list of rvm autolib flags.  It'd be nice to have those.
