### PR TITLE
Problem with 'sg' command on different linux distributions

### DIFF
--- a/lib/rvm/capistrano.rb
+++ b/lib/rvm/capistrano.rb
@@ -140,7 +140,7 @@ module Capistrano
       def with_rvm_group(command)
         case rvm_type
         when :root, :system
-          "sg rvm -c \"#{command}\""
+          "#{sudo} sg rvm -c \"#{command}\""
         else
           command
         end


### PR DESCRIPTION
"sg" apparently asks for a password on ubuntu and centos (tested).

I've tested the command used by rvm-capistrano on my local machine and get the same result (e.g. sg rvm ls).
Using sudo for this command would solve the problem for me, but I have no idea about the implications..
