### PR TITLE
Fix argument error.

### DIFF
--- a/lib/rvm/capistrano/helpers/rvm_methods.rb
+++ b/lib/rvm/capistrano/helpers/rvm_methods.rb
@@ -10,7 +10,7 @@ module Capistrano
     end
 
     # allow running tasks without using rvm_shell
-    def run_without_rvm(command)
+    def run_without_rvm(command, options={})
       run command, :shell => "#{rvm_install_shell}"
     end
 


### PR DESCRIPTION
In run_silent_curl.rb, run_without_rvm() is called with 2 arguments
but the second one is missing in the function definition.
