### PR TITLE
Allow overriding the install url.

### DIFF
--- a/lib/rvm/capistrano/install_rvm.rb
+++ b/lib/rvm/capistrano/install_rvm.rb
@@ -9,8 +9,7 @@ rvm_with_capistrano do
     # Let users set the install type of their choice.
     _cset(:rvm_install_type, :stable)
 
-    # Let users override the installation url
-    _cset(:rvm_install_url, "get.rvm.io")
+    _cset(:rvm_install_url, "https://get.rvm.io")
 
     # By default system installations add deploying user to rvm group. also try :all
     _cset(:rvm_add_to_group, fetch(:user,"$USER"))


### PR DESCRIPTION
I am behind a proxy that for some reason does not guess that 'get.rvm.io' should
be redirected to 'https://get.rvm.io'. With this solution I can explicitely
declare the https url.
Another solution would be to hard code the protocol "https://" within the
variable command_fetch.
