### PR TITLE
Using environment variable RUBY_VERSION if it exists, and failing back t...

### DIFF
--- a/lib/rvm/capistrano/base.rb
+++ b/lib/rvm/capistrano/base.rb
@@ -77,7 +77,11 @@ rvm_with_capistrano do
     set :rvm_ruby_string_evaluated do
       value = fetch(:rvm_ruby_string, :default)
       if value.to_sym == :local
-        value = ENV['GEM_HOME'].gsub(/.*\//,"")
+        if defined? ENV['RUBY_VERSION']
+          value = ENV['RUBY_VERSION'].gsub('ruby-','')
+        else
+          value = ENV['GEM_HOME'].gsub(/.*\//,"")
+        end
       end
       value.to_s
     end


### PR DESCRIPTION
...o GEM_HOME.

Reason being, if your app is using ruby 2.1.2 (and it may be this way for others)
and you run 'bundle install --deployment', you'll find your gems under
bundle/gems/ruby/2.1.0, and this gem thinks your ruby version if 2.1.0, NOT 2.1.2,
which causes obvious issues during deployments.
