### PR TITLE
Fix defined? check on ENV

### DIFF
--- a/lib/rvm/capistrano/base.rb
+++ b/lib/rvm/capistrano/base.rb
@@ -77,7 +77,7 @@ rvm_with_capistrano do
     set :rvm_ruby_string_evaluated do
       value = fetch(:rvm_ruby_string, :default)
       if value.to_sym == :local
-        if defined? ENV['RUBY_VERSION']
+        unless ENV['RUBY_VERSION'].nil?
           value = ENV['RUBY_VERSION'].gsub('ruby-','')
         else
           value = ENV['GEM_HOME'].gsub(/.*\//,"")


### PR DESCRIPTION
I got this Exception after upgrading to the lastest version of rvm-capistrano:

```
/.rvm/gems/ruby-2.1.2/gems/rvm-capistrano-1.5.2/lib/rvm/capistrano/base.rb:84:in `block (3 levels) in <top (required)>': undefined method `gsub' for nil:NilClass (NoMethodError)
  from /.rvm/gems/ruby-2.1.2/gems/capistrano-2.15.5/lib/capistrano/configuration/variables.rb:87:in `call'
```

The defined? check on the ENV variable always evaluates to true.

```
2.1.2 :001 > puts "defined!" if defined?(ENV['foobar'])
defined!
 => nil 
```

I guess a nil-check should be sufficient, right? That's what I did in this PR.
