### PR TITLE
Support release_path or current_path (if in standalone mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ cap rvm:info_list
 
 - `:rvm_ruby_string` - which ruby should be loaded
  - `release_path` - load ruby defined in `#{release_path}` - Capistrano variable pointing where code is checked out
+ - `latest_release` - load ruby defined in `#{release_path}`, if it exists, or `#{current_path}`
  - `local` - detect local machine running ruby using `GEM_HOME`
  - `<ruby-version>` - specify ruby version to use
 

--- a/lib/rvm/capistrano/base.rb
+++ b/lib/rvm/capistrano/base.rb
@@ -10,6 +10,9 @@ rvm_with_capistrano do
       case ruby
       when "release_path"
         shell = "rvm_path=#{rvm_path} #{shell} --path '#{release_path}'"
+      when "latest_release"
+        latest_release_path = exists?(:deploy_timestamped) ? release_path : current_path
+        shell = "rvm_path=#{rvm_path} #{shell} --path '#{latest_release_path}'"
       when "local"
         ruby = (ENV['GEM_HOME'] || "").gsub(/.*\//, "")
         raise "Failed to get ruby version from GEM_HOME. Please make sure rvm is loaded!" if ruby.empty?


### PR DESCRIPTION
Since there is no release_path unless you're deploying, fall back to current_path.

We use Capistrano to run a lot of remote commands. In those cases, there's no `release_path` so rvm-capistrano fails to find the correct Ruby version. It is acceptable to use `current_path` in that case.
